### PR TITLE
Secure storage with secure-storage

### DIFF
--- a/__mocks__/react-native-secure-storage.js
+++ b/__mocks__/react-native-secure-storage.js
@@ -1,0 +1,9 @@
+import { AsyncStorage } from 'react-native';
+
+export {
+  ACCESS_CONTROL,
+  ACCESSIBLE,
+  AUTHENTICATION_TYPE
+} from 'react-native-secure-storage';
+
+export default AsyncStorage;

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,6 +137,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-secure-storage')
     compile project(':react-native-vector-icons')
     compile project(':react-native-device-info')
     implementation fileTree(dir: "libs", include: ["*.jar"])

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
 
     <application
       android:name=".MainApplication"

--- a/android/app/src/main/java/com/sojourn/MainApplication.java
+++ b/android/app/src/main/java/com/sojourn/MainApplication.java
@@ -3,6 +3,7 @@ package com.sojourn;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import li.yunqi.rnsecurestorage.RNSecureStoragePackage;
 import com.oblador.vectoricons.VectorIconsPackage;
 import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import com.facebook.react.ReactNativeHost;
@@ -25,6 +26,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new RNSecureStoragePackage(),
             new VectorIconsPackage(),
             new RNDeviceInfo()
       );

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'sojourn'
+include ':react-native-secure-storage'
+project(':react-native-secure-storage').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-secure-storage/android')
 include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
 include ':react-native-device-info'

--- a/ios/sojourn.xcodeproj/project.pbxproj
+++ b/ios/sojourn.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -14,6 +13,7 @@
 		00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302E41ABCB9EE00DB3ED1 /* libRCTVibration.a */; };
 		00E356F31AD99517003FC87E /* sojournTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* sojournTests.m */; };
 		02F782B7A40A464B9A9121AA /* Nunito-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 182D74EC4C6E42E38019154E /* Nunito-ExtraBold.ttf */; };
+		0578C055171E416BBDC301A6 /* libRNSecureStorage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AA9CE2F74354878A54CCFDB /* libRNSecureStorage.a */; };
 		078ADFDFC6E645B0BBB302A3 /* Feather.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7C4C8D8FD2514E06B13E15B9 /* Feather.ttf */; };
 		0DE8BB8CE9E94BE4B10FC278 /* Nunito-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F414F46AAB83475DA72B54E8 /* Nunito-Black.ttf */; };
 		0E74BD6606374ADAA7740914 /* Nunito-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 06030D9578734962BE4DF2AC /* Nunito-SemiBold.ttf */; };
@@ -321,6 +321,13 @@
 			remoteGlobalIDString = 3D3CD9181DE5FBD800167DC4;
 			remoteInfo = "jschelpers-tvOS";
 		};
+		4C58580E219090480037BAFE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F4273460434E4E5C8806262F /* RNSecureStorage.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RNSecureStorage;
+		};
 		4CBD9691218B43DA00713961 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9EF14A86DE574844BA9D1E16 /* RNDeviceInfo.xcodeproj */;
@@ -427,6 +434,7 @@
 		7C4C8D8FD2514E06B13E15B9 /* Feather.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Feather.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Feather.ttf"; sourceTree = "<group>"; };
 		7D2C131C7CCD422F8D3984F3 /* Nunito-ExtraBoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-ExtraBoldItalic.ttf"; path = "../src/assets/fonts/Nunito-ExtraBoldItalic.ttf"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
+		8AA9CE2F74354878A54CCFDB /* libRNSecureStorage.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNSecureStorage.a; sourceTree = "<group>"; };
 		8F233EA559B5464DBC5E5478 /* Nunito-LightItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-LightItalic.ttf"; path = "../src/assets/fonts/Nunito-LightItalic.ttf"; sourceTree = "<group>"; };
 		93374D4185CC4FEF98F0193F /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
 		9D1CD3BCADE84B54A491F036 /* MaterialCommunityIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialCommunityIcons.ttf; path = "../node_modules/native-base/Fonts/MaterialCommunityIcons.ttf"; sourceTree = "<group>"; };
@@ -449,6 +457,7 @@
 		F2E017536A0B4D21B12F54BA /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/native-base/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
 		F3E58408E56C492A9D52A331 /* Nunito-ExtraLightItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-ExtraLightItalic.ttf"; path = "../src/assets/fonts/Nunito-ExtraLightItalic.ttf"; sourceTree = "<group>"; };
 		F414F46AAB83475DA72B54E8 /* Nunito-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-Black.ttf"; path = "../src/assets/fonts/Nunito-Black.ttf"; sourceTree = "<group>"; };
+		F4273460434E4E5C8806262F /* RNSecureStorage.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNSecureStorage.xcodeproj; path = "../node_modules/react-native-secure-storage/ios/RNSecureStorage.xcodeproj"; sourceTree = "<group>"; };
 		F8C5ECAE75704C6B9208BC4A /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -479,6 +488,7 @@
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				400FCBCD9988409AAA25AA59 /* libRNDeviceInfo.a in Frameworks */,
 				8C315BE7918447658F98A654 /* libRNVectorIcons.a in Frameworks */,
+				0578C055171E416BBDC301A6 /* libRNSecureStorage.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -679,12 +689,21 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		4C58580B219090460037BAFE /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4C58580F219090480037BAFE /* libRNSecureStorage.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		4CBD9665218B43D500713961 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
 				58A54B8FA7504B8D9C2F1DEA /* libRNDeviceInfo.a */,
 				730E9C5826234BC8A6CF41F8 /* libRNVectorIcons.a */,
 				61AD2B3EF1334B2C8E1128A6 /* libRNDeviceInfo-tvOS.a */,
+				8AA9CE2F74354878A54CCFDB /* libRNSecureStorage.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -741,6 +760,7 @@
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
 				9EF14A86DE574844BA9D1E16 /* RNDeviceInfo.xcodeproj */,
 				4EC5E187214E41E7837A7CB9 /* RNVectorIcons.xcodeproj */,
+				F4273460434E4E5C8806262F /* RNSecureStorage.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -956,6 +976,10 @@
 				{
 					ProductGroup = 4CBD968B218B43D800713961 /* Products */;
 					ProjectRef = 9EF14A86DE574844BA9D1E16 /* RNDeviceInfo.xcodeproj */;
+				},
+				{
+					ProductGroup = 4C58580B219090460037BAFE /* Products */;
+					ProjectRef = F4273460434E4E5C8806262F /* RNSecureStorage.xcodeproj */;
 				},
 				{
 					ProductGroup = 4CBD968D218B43D800713961 /* Products */;
@@ -1197,6 +1221,13 @@
 			remoteRef = 3DAD3EAE1DF850E9000B6D8A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		4C58580F219090480037BAFE /* libRNSecureStorage.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNSecureStorage.a;
+			remoteRef = 4C58580E219090480037BAFE /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		4CBD9692218B43DA00713961 /* libRNDeviceInfo.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1435,12 +1466,14 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-secure-storage/ios/**",
 				);
 				INFOPLIST_FILE = sojournTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -1465,12 +1498,14 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-secure-storage/ios/**",
 				);
 				INFOPLIST_FILE = sojournTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -1496,6 +1531,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-secure-storage/ios/**",
 				);
 				INFOPLIST_FILE = sojourn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1520,6 +1556,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-secure-storage/ios/**",
 				);
 				INFOPLIST_FILE = sojourn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1550,11 +1587,13 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-secure-storage/ios/**",
 				);
 				INFOPLIST_FILE = "sojourn-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -1587,11 +1626,13 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-secure-storage/ios/**",
 				);
 				INFOPLIST_FILE = "sojourn-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -1623,11 +1664,13 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-secure-storage/ios/**",
 				);
 				INFOPLIST_FILE = "sojourn-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -1659,11 +1702,13 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-secure-storage/ios/**",
 				);
 				INFOPLIST_FILE = "sojourn-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",

--- a/ios/sojourn/Info.plist
+++ b/ios/sojourn/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Enabling Face ID allows you quick and secure access to your notes.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-native": "0.57.2",
     "react-native-device-info": "^0.24.3",
     "react-native-dotenv": "^0.2.0",
+    "react-native-secure-storage": "^0.1.1",
     "react-native-uport-connect": "^0.1.3",
     "react-navigation": "^2.18.0",
     "react-redux": "^5.0.7",

--- a/src/modules/meatGrinder/EditNoteScreen.js
+++ b/src/modules/meatGrinder/EditNoteScreen.js
@@ -12,18 +12,29 @@ import {
   Text,
   Title
 } from 'native-base';
+import { connect } from 'react-redux';
 import theme from '../../theme/variables';
+import { web3 } from '../signIn/uport';
+import { persistHash } from './meatGrinderReducer';
 
 /**
  * Screen to allow users to create or edit a note
  */
-class EditNoteScreen extends PureComponent {
+export class EditNoteScreen extends PureComponent {
   static propTypes = {
-    navigation: PropTypes.object
+    navigation: PropTypes.object,
+    persistHash: PropTypes.func
   };
 
   goBack = () => {
     this.props.navigation.goBack();
+  };
+
+  handleSave = () => {
+    const { persistHash } = this.props;
+    const hash = web3.utils.sha3(Date.now().toString());
+
+    persistHash(hash);
   };
 
   /**
@@ -55,7 +66,7 @@ class EditNoteScreen extends PureComponent {
             <Title>New Note</Title>
           </Body>
           <Right>
-            <Button transparent>
+            <Button transparent onPress={this.handleSave}>
               <Text>Save</Text>
             </Button>
           </Right>
@@ -111,4 +122,9 @@ const styles = StyleSheet.create({
   }
 });
 
-export default EditNoteScreen;
+const mapDispatchToProps = { persistHash };
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(EditNoteScreen);

--- a/src/modules/meatGrinder/EditNoteScreen.test.js
+++ b/src/modules/meatGrinder/EditNoteScreen.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import EditNoteScreen from './EditNoteScreen';
+import { EditNoteScreen } from './EditNoteScreen';
 import { StyleProvider } from 'native-base';
 import render from 'react-test-renderer';
 import theme from '../../theme';

--- a/src/modules/signIn/SignInScreen.js
+++ b/src/modules/signIn/SignInScreen.js
@@ -8,22 +8,36 @@ import { isSignedIn } from './signInSelectors';
 /**
  * Sign in screen. Allows users to log in with uPort.
  */
-class SignInScreen extends Component {
+export class SignInScreen extends Component {
   static propTypes = {
     navigation: PropTypes.object,
     isSignedIn: PropTypes.bool
   };
 
   /**
-   * Navigates to Application router when signed in
+   * Called on prop update
    */
   componentDidUpdate() {
+    this.navigateOnSignIn();
+  }
+
+  /**
+   * Called on mount
+   */
+  componentDidMount() {
+    this.navigateOnSignIn();
+  }
+
+  /**
+   * Navigates to Application router when signed in
+   */
+  navigateOnSignIn = () => {
     const { navigation, isSignedIn } = this.props;
 
     if (isSignedIn) {
       navigation.navigate('App');
     }
-  }
+  };
 
   /**
    * Dispatches sign in redux action

--- a/src/modules/signIn/SignInScreen.test.js
+++ b/src/modules/signIn/SignInScreen.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { SignInScreen } from './SignInScreen';
+import { StyleProvider } from 'native-base';
+import render from 'react-test-renderer';
+import theme from '../../theme';
+
+describe('Edit Note Screen', () => {
+  let navigation;
+
+  beforeEach(() => {
+    navigation = { navigate: jest.fn() };
+  });
+
+  it('Does not redirect if not logged in', () => {
+    render.create(
+      <StyleProvider style={theme}>
+        <SignInScreen navigation={navigation} isSignedIn={false} />
+      </StyleProvider>
+    );
+
+    expect(navigation.navigate).not.toHaveBeenCalled();
+  });
+
+  it('Redirects if user is logged in', () => {
+    render.create(
+      <StyleProvider style={theme}>
+        <SignInScreen navigation={navigation} isSignedIn={true} />
+      </StyleProvider>
+    );
+
+    expect(navigation.navigate).toHaveBeenCalledWith('App');
+  });
+});

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,14 +1,14 @@
 import { createStore, applyMiddleware } from 'redux';
 import { persistStore, persistReducer } from 'redux-persist';
 import thunk from 'redux-thunk';
-import storage from 'redux-persist/lib/storage';
+import secureStorage from './secureStorage';
 import stateReconciler from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 
 import rootReducer from './reducer';
 
 const persistConfig = {
   key: 'StoreRoot',
-  storage,
+  storage: secureStorage,
   stateReconciler
 };
 

--- a/src/store/secureStorage.js
+++ b/src/store/secureStorage.js
@@ -1,0 +1,19 @@
+import SecureStorage, {
+  ACCESS_CONTROL,
+  ACCESSIBLE,
+  AUTHENTICATION_TYPE
+} from 'react-native-secure-storage';
+
+const config = {
+  accessControl: ACCESS_CONTROL.BIOMETRY_ANY_OR_DEVICE_PASSCODE,
+  accessible: ACCESSIBLE.WHEN_UNLOCKED,
+  authenticationPrompt: 'Log in to Sojourn',
+  service: 'sojourn',
+  authenticateType: AUTHENTICATION_TYPE.BIOMETRICS
+};
+
+export default Object.keys(SecureStorage).reduce((exports, fnName) => {
+  exports[fnName] = (...args) => SecureStorage[fnName](...args, config);
+
+  return exports;
+}, {});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7206,6 +7206,10 @@ react-native-screens@^1.0.0-alpha.11:
   version "1.0.0-alpha.15"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-1.0.0-alpha.15.tgz#5b5a0041310b46f12048fda1908d52e7290ec18f"
 
+react-native-secure-storage@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-secure-storage/-/react-native-secure-storage-0.1.1.tgz#8216476d9237c1d5e0a62da339dae071a84e3e7e"
+
 react-native-tab-view@^0.0.77:
   version "0.0.77"
   resolved "http://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-0.0.77.tgz#11ceb8e7c23100d07e628dc151b57797524d00d4"


### PR DESCRIPTION
**Related Issue**  
Supports #39 

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Adds secure-storage (with biometrics) to encrypt/decrypt the state which will eventually include notes. So, this protects the notes at rest on the device and forces a faceId login always before opening the app.

**Description of Changes**  
Uses react-secure-storage to do all the things. I investigated redux-persist-sensitive-storage, which still _looks_ like a better option, but I couldn't get it to faceId, or touchId, or anything really? It would be nice to have it though sense it looks more mature.

**What gif most accurately describes how I feel towards this PR?**  
![vault](https://media2.giphy.com/media/dKeVTrQ5vQJxu/giphy.gif)
